### PR TITLE
Add auto-geocoding on offender registration

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -54,6 +54,30 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
+  // Autocompletar coordenadas usando Nominatim
+  const lugarInput = document.getElementById('ultimo_lugar');
+  const latInput = document.getElementById('latitud');
+  const lonInput = document.getElementById('longitud');
+  if (lugarInput && latInput && lonInput) {
+    lugarInput.addEventListener('blur', () => {
+      const query = lugarInput.value.trim();
+      if (!query) return;
+      const url =
+        `https://nominatim.openstreetmap.org/search?format=json&limit=1&q=${encodeURIComponent(query)}`;
+      fetch(url, { headers: { 'User-Agent': 'prevcrim-app' } })
+        .then(r => r.json())
+        .then(data => {
+          if (data.length) {
+            latInput.value = data[0].lat;
+            lonInput.value = data[0].lon;
+          }
+        })
+        .catch(err => {
+          console.error('Geocoding error', err);
+        });
+    });
+  }
+
 // Avisar al usuario con un mensaje informativo en caso de que le de al boton sin rellenar el formulario en reportes
 const input = document.getElementById("ing_list_del");
 


### PR DESCRIPTION
## Summary
- fetch latitude and longitude from Nominatim API when `último lugar visto` is filled

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841c667f2e88326b0a94f4e7c69bf4a