### PR TITLE
Fix script error when report form not present

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -54,16 +54,21 @@ document.addEventListener("DOMContentLoaded", () => {
     });
   }
 
-// Avisar al usuario con un mensaje informativo en caso de que le de al boton sin rellenar el formulario en reportes
-const input = document.getElementById("ing_list_del");
+// Avisar al usuario con un mensaje informativo en caso de que presione el
+// botón de búsqueda sin rellenar el formulario en reportes. El elemento solo
+// existe en reportes.php, por lo que verificamos su presencia antes de añadir
+// los listeners para evitar errores en otras páginas.
+const searchInput = document.getElementById("ing_list_del");
 
-input.addEventListener("invalid", (event) => {
-  input.setCustomValidity("Por favor, rellenar el campo.");
-});
+if (searchInput) {
+  searchInput.addEventListener("invalid", () => {
+    searchInput.setCustomValidity("Por favor, rellenar el campo.");
+  });
 
-input.addEventListener("input", (event) => {
-  input.setCustomValidity("");
-});
+  searchInput.addEventListener("input", () => {
+    searchInput.setCustomValidity("");
+  });
+}
 
 
 


### PR DESCRIPTION
## Summary
- prevent errors when `ing_list_del` isn't on the page

## Testing
- `node -c js/script.js`

------
https://chatgpt.com/codex/tasks/task_e_6841c1d00f7c8326806c4a10570d7a1d